### PR TITLE
expose UserProfile to the package consumers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 module.exports = {
 	Bot: require(__dirname + '/viber-bot'),
 	Events: require(__dirname + '/event-consts'),
+	UserProfile: require(__dirname + '/user-profile'),
 	Message: {
 		Text: require(__dirname + '/message/text-message'),
 		Url: require(__dirname + '/message/url-message'),


### PR DESCRIPTION
Hi!
This pull requests exposes UserProfile class to the package consumers.
Why is this needed?
If you are using `viber-bot` as a middleware to receive and send messages and have conversation logic somewhere else you need to re-construct `UserProfile` to send a message to the correct user.

Right now it is impossible since `ViberBot.sendMessage` needs a `UserProfile` object to send message.

I'm open for a feedback since there might be better ways of doing that.

Sample code with changes in this PR:

```
 var self = this;
 var address = message.address; //contains user id and user name of viber recepient
 var profile = new UserProfile(address.user.id, address.user.name, '','','');
 if (message.text && message.text.length > 0) {
       this.viberBot.sendMessage(profile, [ self.convertToViberMessage(message) ]);
 }
```