### PR TITLE
Fix crypto TypeError Data must be a string or a buffer

### DIFF
--- a/lib/message/message-validator.js
+++ b/lib/message/message-validator.js
@@ -8,6 +8,7 @@ function MessageValidator(logger, authToken) {
 }
 
 MessageValidator.prototype.validateMessage = function(serverSideSignature, message) {
+	if (typeof message !== "string") message = JSON.stringify(message)
 	const calculatedHash = this._calculateHmacFromMessage(message);
 	this._logger.debug("Validating signature '%s' == '%s'", serverSideSignature, calculatedHash);
 	return serverSideSignature == calculatedHash;


### PR DESCRIPTION
I was having issues using this bot in my project, since it automatically parses JSON requests, crpyto was receiving an object instead a string, thus causing this error.