### PR TITLE
Fix "ReferenceError: optionalUserProfile is not defined"

### DIFF
--- a/lib/viber-bot.js
+++ b/lib/viber-bot.js
@@ -203,7 +203,7 @@ ViberBot.prototype._getMissingFieldsInConfiguration = function(configuration) {
 	return _.difference(REQUIRED_CONFIGURATION_FIELDS, Object.keys(configuration));
 };
 
-ViberBot.prototype._sendMessageFromClient = function(optionalUserProfile, message, optionalTrackingData, optionalKeyboard, optionalChatId, optionalMinApiVersion) {
+ViberBot.prototype._sendMessageFromClient = function(userProfile, message, optionalTrackingData, optionalKeyboard, optionalChatId, optionalMinApiVersion) {
 	const jsonMessage = message.toJson();
 	let receiver = null;
 	if (optionalUserProfile) {


### PR DESCRIPTION
Fix for "UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): ReferenceError: optionalUserProfile is not defined" when sending array of messages.

Sending array of messages used to work in v1.0.11, however v1.0.12 breaks this functionality.