### PR TITLE
Fix "ReferenceError: optionalUserProfile is not defined"

### DIFF
--- a/lib/viber-bot.js
+++ b/lib/viber-bot.js
@@ -114,7 +114,7 @@ ViberBot.prototype._sendMessages = function(userProfile, messages, requestType, 
 		}));
 
 		promise = promise.then(() => new Promise((resolve, reject) => {
-			if (requestType == REQUEST_TYPE.SEND_MESSAGE) return self._sendMessageFromClient(optionalUserProfile, message, null, null, optionalChatId, message.minApiVersion).then(response => resolveCallback(response, message, resolve, reject));
+			if (requestType == REQUEST_TYPE.SEND_MESSAGE) return self._sendMessageFromClient(userProfile, message, null, null, optionalChatId, message.minApiVersion).then(response => resolveCallback(response, message, resolve, reject));
 			if (requestType == REQUEST_TYPE.POST_TO_PUBLIC_CHAT) return self._sendMessageToPublicChat(userProfile, message);
 			return reject(`internal error: unknown RequestType=${requestType}`);
 		}));


### PR DESCRIPTION
Fix `UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): ReferenceError: optionalUserProfile is not defined` when sending array of messages.

Sending array of messages used to work up until v1.0.11, which broke this functionality due to wrong argument name (optionalUserProfile should be userProfile).