### PR TITLE
Fix failed request in chat extensions

### DIFF
--- a/lib/viber-client.js
+++ b/lib/viber-client.js
@@ -48,7 +48,6 @@ ViberClient.prototype.sendMessage = function(optionalReceiver, messageType, mess
 	}
 
 	const request = {
-		"receiver": optionalReceiver,
 		"sender": {
 			"name": this._bot.name,
 			"avatar": this._bot.avatar
@@ -58,6 +57,10 @@ ViberClient.prototype.sendMessage = function(optionalReceiver, messageType, mess
 		"chat_id": optionalChatId,
 		"min_api_version": optionalMinApiVersion
 	};
+
+	if (optionalReceiver) {
+		request["receiver"] = optionalReceiver;
+	}
 
 	this._logger.debug("Sending %s message to viber user '%s' with data", messageType, optionalReceiver, messageData);
 	return this._sendRequest("sendMessage", Object.assign(request, messageData));


### PR DESCRIPTION
Receiver parameter should not be included in the request if its value is null