### PR TITLE
Added "path" to config, to run bot on non-root URLS and run multiple bots on same site

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -4,7 +4,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const stream = require('stream');
 
-function Middleware(logger, messageValidatorService) {
+function Middleware(logger, messageValidatorService, path) {
 	this._logger = logger;
 	this._stream = this._createStream();
 	this._buffer = null;
@@ -13,7 +13,7 @@ function Middleware(logger, messageValidatorService) {
 	this._app.use(bodyParser.text({ type: "*/*" }));
 
 	this._validateMessageSignature(messageValidatorService);
-	this._configureEndpoints();
+	this._configureEndpoints(path);
 }
 
 Middleware.prototype.getIncoming = function() {
@@ -24,14 +24,14 @@ Middleware.prototype.getStream = function() {
 	return this._stream;
 };
 
-Middleware.prototype._configureEndpoints = function() {
+Middleware.prototype._configureEndpoints = function(path) {
 	const self = this;
-	this._app.get("/ping", (request, response) => {
+	this._app.get(path+"/ping", (request, response) => {
 		response.send("pong");
 		response.end();
 	});
 
-	this._app.post("/", (request, response) => {
+	this._app.post(path+"/", (request, response) => {
 		self._logger.debug("Request data:", request.body);
 		self._stream.push(request.body);
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -8,7 +8,7 @@ function Middleware(logger, messageValidatorService, path) {
 	this._logger = logger;
 	this._stream = this._createStream();
 	this._buffer = null;
-
+	this._path=path;
 	this._app = express();
 	this._app.use(bodyParser.text({ type: "*/*" }));
 
@@ -24,14 +24,14 @@ Middleware.prototype.getStream = function() {
 	return this._stream;
 };
 
-Middleware.prototype._configureEndpoints = function(path) {
+Middleware.prototype._configureEndpoints = function() {
 	const self = this;
-	this._app.get(path+"/ping", (request, response) => {
+	this._app.get(self._path+"/ping", (request, response) => {
 		response.send("pong");
 		response.end();
 	});
 
-	this._app.post(path+"/", (request, response) => {
+	this._app.post(self._path+"/", (request, response) => {
 		self._logger.debug("Request data:", request.body);
 		self._stream.push(request.body);
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -13,7 +13,7 @@ function Middleware(logger, messageValidatorService, path) {
 	this._app.use(bodyParser.text({ type: "*/*" }));
 
 	this._validateMessageSignature(messageValidatorService);
-	this._configureEndpoints(path);
+	this._configureEndpoints();
 }
 
 Middleware.prototype.getIncoming = function() {

--- a/lib/viber-bot.js
+++ b/lib/viber-bot.js
@@ -56,7 +56,7 @@ function ViberBot(loggerOrConfiguration, configuration) {
 
 	this._logger = logger;
 	this._client = new ViberClient(this._logger, this, API_URL, configuration.registerToEvents || SUBSCRIBED_EVENTS);
-	this._middleware = new Middleware(this._logger, new MessageValidator(this._logger, this.authToken));
+	this._middleware = new Middleware(this._logger, new MessageValidator(this._logger, this.authToken),configuration.path);
 	this._messageFactory = new MessageFactory(this._logger);
 	this._regexMatcherRouter = new RegexMatcherRouter(this._logger);
 	this._callbacks = { [EventConsts.CONVERSATION_STARTED]: []};


### PR DESCRIPTION
If you need the bot to be run on non-root URL, for example **www.site.com/mybot/runhere** or if you want run multiple bots on the same site, for example www.site.com/bots/01, www.site.com/bots/02, www.site.com/bots/03, and so on. There is additional configuration option for this: 
use 

```
const bot = new ViberBot({
	authToken: YOUR_AUTH_TOKEN_HERE,
	name: "EchoBot",
	avatar: "http://viber.com/avatar.jpg",
        path: '/mybot/runhere'
});

```