### PR TITLE
Delete min_api_version reference in toJson()

### DIFF
--- a/lib/message/rich-media-message.js
+++ b/lib/message/rich-media-message.js
@@ -24,8 +24,7 @@ RichMediaMessage.prototype.toJson = function() {
 	return {
 		"type": RichMediaMessage.getType(),
 		"rich_media": this.richMedia,
-		"alt_text": this.altText || null,
-		"min_api_version": 2
+		"alt_text": this.altText || null
 	};
 };
 


### PR DESCRIPTION
In that way it is possible to attach a keyboard with features that require an api level bigger than the api level 2.