### PR TITLE
Add reject handler to bot sendMessage method to avoid UnhandledPromiseRejectionWarning

### DIFF
--- a/lib/viber-bot.js
+++ b/lib/viber-bot.js
@@ -122,12 +122,12 @@ ViberBot.prototype._sendMessages = function(userProfile, messages, requestType, 
 
 	return promise.then(() => new Promise((resolve, reject) => {
 		if (requestType == REQUEST_TYPE.SEND_MESSAGE) {
-				return self._sendMessageFromClient(userProfile, lastMessage, optionalTrackingData, lastMessage.keyboard, optionalChatId, lastMessage.minApiVersion)
-											.then(response => resolveCallback(response, lastMessage, resolve, reject));
+			return self._sendMessageFromClient(userProfile, lastMessage, optionalTrackingData, lastMessage.keyboard, optionalChatId, lastMessage.minApiVersion)
+											.then(response => resolveCallback(response, lastMessage, resolve, reject), error => reject(error));
 		}
 		if (requestType == REQUEST_TYPE.POST_TO_PUBLIC_CHAT) {
 			return self._sendMessageToPublicChat(userProfile, lastMessage, lastMessage.minApiVersion).then(response => resolveCallback(response, lastMessage, resolve, reject))
-											.then(response => resolveCallback(response, lastMessage, resolve, reject));
+											.then(response => resolveCallback(response, lastMessage, resolve, reject), error => reject(error));
 		}
 		return reject(`internal error: unknown RequestType=${requestType}`);
 	}))


### PR DESCRIPTION
Without this handler bot.sendMessage can throw UnhandledPromiseRejectionWarning

```js
let r = await this.bot.sendMessage(up, new TextMessage(message)).catch(e => console.error(e));
```

> (node:5092) UnhandledPromiseRejectionWarning: #<Object>
> (node:5092) UnhandledPromiseRejectionWarning: Unhandled promise 
> (node:5092) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
