### PR TITLE
Fix: ValidateMessageService fails on GET requests (e. g. /ping)

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -58,7 +58,8 @@ Middleware.prototype._validateMessageSignature = function(messageValidatorServic
 	const self = this;
 	this._app.use((request, response, next) => {
 		const serverSideSignature = request.headers.X_Viber_Content_Signature || request.query.sig;
-		if (!messageValidatorService.validateMessage(serverSideSignature, request.body)) {
+		const requestSignature = request.query.validation || request.body;
+		if (!messageValidatorService.validateMessage(serverSideSignature, requestSignature)) {
 			self._logger.warn("Could not validate message signature", serverSideSignature);
 			return;
 		}

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "express": "^4.14.0",
     "needle": "^1.1.0",
     "underscore": "^1.8.3",
-		"json-bigint": "^0.2.3"
+    "json-bigint": "^0.2.3"
   },
   "devDependencies": {
     "eslint": "^2.10.1",
-		"express": "^4.14.0",
-    "nodeunit": "~0.10.2"
+    "express": "^4.14.0",
+    "nodeunit": "^0.11.3"
   }
 }


### PR DESCRIPTION
Bot middleware has standard endpoint `/ping` configured.

Because of validation based on `request.body` - GET requests doesn't work.

Here's (passing `validation=` query param) possible solution without skipping `sig=` query param

P. S.: You should calculate `sig` and `validation` by yourself

example of calculation
```bash
$ echo -n "<value-you-pass-in-validation>" | openssl dgst -sha256 -hmac "<your-viber-token>"

# let's assume hmac is "1234"
$ curl "https://your.bot.public.api/ping?sig=5feee0d19f20824ac33967633125a76e4f916a7888c60bf777a0eec5a1555114&validation=valid"
# should work now :-)
```