### PR TITLE
add default min api version and option to specify min api version to TextMessage

### DIFF
--- a/lib/message/text-message.js
+++ b/lib/message/text-message.js
@@ -22,7 +22,8 @@ TextMessage.getType = function() {
 TextMessage.prototype.toJson = function() {
 	return {
 		"type": TextMessage.getType(),
-		"text": this.text
+		"text": this.text,
+		"min_api_version": 2 || this.minApiVersion
 	};
 };
 

--- a/lib/message/text-message.js
+++ b/lib/message/text-message.js
@@ -23,7 +23,7 @@ TextMessage.prototype.toJson = function() {
 	return {
 		"type": TextMessage.getType(),
 		"text": this.text,
-		"min_api_version": 2 || this.minApiVersion
+		"min_api_version": this.minApiVersion || 2
 	};
 };
 


### PR DESCRIPTION
Added option to specify min_api_version in `TextMessage`. Useful when sending keyboard with `TextMessage` where the keyboard has options for higher API levels example`InputType: hidden` with some greetings keyboard.