### PR TITLE
Bug fix for GET requests

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -57,10 +57,12 @@ Middleware.prototype._createStream = function() {
 Middleware.prototype._validateMessageSignature = function(messageValidatorService) {
 	const self = this;
 	this._app.use((request, response, next) => {
-		const serverSideSignature = request.headers.X_Viber_Content_Signature || request.query.sig;
-		if (!messageValidatorService.validateMessage(serverSideSignature, request.body)) {
-			self._logger.warn("Could not validate message signature", serverSideSignature);
-			return;
+		if (request.method == 'POST') {
+			const serverSideSignature = request.headers.X_Viber_Content_Signature || request.query.sig;
+			if (!messageValidatorService.validateMessage(serverSideSignature, request.body)) {
+				self._logger.warn("Could not validate message signature", serverSideSignature);
+				return;
+			}
 		}
 		next();
 	});


### PR DESCRIPTION
_validateMessageSignature should only handle POST requests, otherwise all GET requests (including the /ping from line 29) result in a 500 error.